### PR TITLE
Use getent instead of dig

### DIFF
--- a/known_hosts
+++ b/known_hosts
@@ -49,7 +49,7 @@ then
   owner=$(whoami)
 fi
 
-ip=$(dig $host +short)
+ip=$(getent hosts $host | cut -f 1 -d ' ')
 
 keygen_name=$host
 if [ -z "$port" -a $port -ne 22 ]


### PR DESCRIPTION
Fixes the dependency on dig, closing issue #4

Also allows you to use an IP as the host address.
(dig returns empty if there is no DNS info available)